### PR TITLE
Applying Rust changes to add tags

### DIFF
--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -6,7 +6,7 @@ use db::RocksDB;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey, EXPANDED_SECRET_KEY_LENGTH};
 use neon::{prelude::*, types::buffer::TypedArray};
 use std::{convert::TryInto, sync::Mutex};
-use store::{LinkStore, ReactionStore, Store, UserDataStore};
+use store::{LinkStore, ReactionStore, TagStore, Store, UserDataStore};
 use threadpool::ThreadPool;
 
 mod db;
@@ -169,6 +169,23 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function(
         "getReactionsByTarget",
         ReactionStore::js_get_reactions_by_target,
+    )?;
+
+    // TagStore methods
+    cx.export_function("createTagStore", TagStore::create_tag_store)?;
+    cx.export_function("getTagAdd", TagStore::js_get_tag_add)?;
+    cx.export_function("getTagRemove", TagStore::js_get_tag_remove)?;
+    cx.export_function(
+        "getTagAddsByFid",
+        TagStore::js_get_tag_adds_by_fid,
+    )?;
+    cx.export_function(
+        "getTagRemovesByFid",
+        TagStore::js_get_tag_removes_by_fid,
+    )?;
+    cx.export_function(
+        "getTagByTarget",
+        TagStore::js_get_tags_by_target,
     )?;
 
     // CastStore methods

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -129,6 +129,10 @@ pub enum UserPostfix {
 
     /* Link Compact State set */
     LinkCompactStateMessage = 100,
+
+    /** TagStore add and remove sets */
+    TagAdds = 101,
+    TagRemoves = 102,
 }
 
 impl UserPostfix {

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -74,7 +74,8 @@ pub enum RootPrefix {
     /* Used to index fname username proofs by fid */
     FNameUserNameProofByFid = 27,
 
-    // VIC-TODO: add tags by target id index
+    /* Used to index tags by target  */
+    TagsByTarget = 28,
 }
 
 /** Copied from the JS code */
@@ -91,6 +92,10 @@ pub enum UserPostfix {
     UsernameProofMessage = 7,
 
     // Add new message types here
+
+    /* Tag message */
+    TagMessage = 8,
+
     // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
     // If you need to store an index, use one of the UserPostfix values below (>86).
     /** Index records (must be 86-255) */
@@ -124,9 +129,6 @@ pub enum UserPostfix {
 
     /* Link Compact State set */
     LinkCompactStateMessage = 100,
-
-    /* Tag message */
-    TagMessage = 101,
 }
 
 impl UserPostfix {

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -73,6 +73,8 @@ pub enum RootPrefix {
 
     /* Used to index fname username proofs by fid */
     FNameUserNameProofByFid = 27,
+
+    // VIC-TODO: add tags by target id index
 }
 
 /** Copied from the JS code */
@@ -122,6 +124,9 @@ pub enum UserPostfix {
 
     /* Link Compact State set */
     LinkCompactStateMessage = 100,
+
+    /* Tag message */
+    TagMessage = 101,
 }
 
 impl UserPostfix {
@@ -181,6 +186,10 @@ pub fn type_to_set_postfix(message_type: MessageType) -> UserPostfix {
 
     if message_type == MessageType::UsernameProof {
         return UserPostfix::UsernameProofMessage;
+    }
+
+    if message_type == MessageType::TagAdd || message_type == MessageType::TagRemove {
+        return UserPostfix::TagMessage;
     }
 
     panic!("invalid type");

--- a/apps/hubble/src/addon/src/store/mod.rs
+++ b/apps/hubble/src/addon/src/store/mod.rs
@@ -21,4 +21,4 @@ mod user_data_store;
 mod username_proof_store;
 mod utils;
 mod verification_store;
-mod taf_store;
+mod tag_store;

--- a/apps/hubble/src/addon/src/store/mod.rs
+++ b/apps/hubble/src/addon/src/store/mod.rs
@@ -8,6 +8,7 @@ pub use self::user_data_store::*;
 pub use self::username_proof_store::*;
 pub use self::utils::*;
 pub use self::verification_store::*;
+pub use self::tag_store::*;
 
 mod cast_store;
 mod link_store;
@@ -20,3 +21,4 @@ mod user_data_store;
 mod username_proof_store;
 mod utils;
 mod verification_store;
+mod taf_store;

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -20,7 +20,7 @@ import { WarpcastTestCommand } from "./warpcastTestCommand.js";
 import { SyncId } from "../network/sync/syncId.js";
 import { TrackHubDelayCommand } from "./trackHubDelayCommand.js";
 
-export const DEFAULT_RPC_CONSOLE = "localhost:2283";
+export const DEFAULT_RPC_CONSOLE = "127.0.0.1:2283";
 
 export interface ConsoleCommandInterface {
   commandName(): string;

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -472,6 +472,57 @@ export const rsGetReactionsByTarget = async (
   return await lib.getReactionsByTarget.call(store, targetCastIdBytes, targetUrl, type, pageOptions);
 };
 
+/** Tags **/
+
+export const rsGetTagAdd = async (
+  store: RustDynStore,
+  fid: number,
+  value: string,
+  targetCastIdBytes: Buffer,
+  targetUrl: string,
+): Promise<Buffer> => {
+  return await lib.getTagAdd.call(store, fid, value, targetCastIdBytes, targetUrl);
+};
+
+export const rsGetTagRemove = async (
+  store: RustDynStore,
+  fid: number,
+  value: number,
+  targetCastIdBytes: Buffer,
+  targetUrl: string,
+): Promise<Buffer> => {
+  return await lib.getTagRemove.call(store, fid, value, targetCastIdBytes, targetUrl);
+};
+
+export const rsGetTagAddsByFid = async (
+  store: RustDynStore,
+  fid: number,
+  value: string,
+  pageOptions: PageOptions,
+): Promise<RustMessagesPage> => {
+  return await lib.getTagAddsByFid.call(store, fid, value, pageOptions);
+};
+
+export const rsGetTagRemovesByFid = async (
+  store: RustDynStore,
+  fid: number,
+  type: number,
+  pageOptions: PageOptions,
+): Promise<RustMessagesPage> => {
+  return await lib.getTagRemovesByFid.call(store, fid, type, pageOptions);
+};
+
+export const rsGetTagsByTarget = async (
+  store: RustDynStore,
+  targetCastIdBytes: Buffer,
+  targetUrl: string,
+  value: string,
+  pageOptions: PageOptions,
+): Promise<RustMessagesPage> => {
+  return await lib.getTagsByTarget.call(store, targetCastIdBytes, targetUrl, value, pageOptions);
+};
+
+
 /** UserData Store */
 export const rsCreateUserDataStore = (
   db: RustDb,

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -303,6 +303,17 @@ export const rsCreateReactionStore = (
   return store as RustDynStore;
 };
 
+/** Create a tag Store */
+export const rsCreateTagStore = (
+  db: RustDb,
+  eventHandler: RustStoreEventHandler,
+  pruneSizeLimit: number,
+): RustDynStore => {
+  const store = lib.createTagStore(db, eventHandler, pruneSizeLimit);
+
+  return store as RustDynStore;
+};
+
 /** Create a cast Store */
 export const rsCreateCastStore = (
   db: RustDb,
@@ -506,10 +517,10 @@ export const rsGetTagAddsByFid = async (
 export const rsGetTagRemovesByFid = async (
   store: RustDynStore,
   fid: number,
-  type: number,
+  value: string,
   pageOptions: PageOptions,
 ): Promise<RustMessagesPage> => {
-  return await lib.getTagRemovesByFid.call(store, fid, type, pageOptions);
+  return await lib.getTagRemovesByFid.call(store, fid, value, pageOptions);
 };
 
 export const rsGetTagsByTarget = async (

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -487,7 +487,7 @@ export const rsGetTagAdd = async (
 export const rsGetTagRemove = async (
   store: RustDynStore,
   fid: number,
-  value: number,
+  value: string,
   targetCastIdBytes: Buffer,
   targetUrl: string,
 ): Promise<Buffer> => {

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -113,6 +113,10 @@ export const typeToSetPostfix = (type: MessageType): UserMessagePostfix => {
     return UserPostfix.LinkCompactStateMessage;
   }
 
+  if (type === MessageType.TAG_ADD || type === MessageType.TAG_REMOVE) {
+    return UserPostfix.TagMessage;
+  }
+
   throw new Error(`invalid type: ${type}`);
 };
 

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -101,6 +101,10 @@ export enum UserPostfix {
   UsernameProofMessage = 7,
 
   // Add new message types here
+
+  /* Tag */
+  TagMessage = 8,
+
   // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
   // If you need to store an index, use one of the UserPostfix values below (>86).
 
@@ -136,9 +140,6 @@ export enum UserPostfix {
 
   /* Link Compact State set */
   LinkCompactStateMessage = 100,
-
-  /* Tag */
-  TagMessage = 101,
 }
 
 export enum OnChainEventPostfix {

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -78,6 +78,9 @@ export enum RootPrefix {
 
   /* Used to index fname username proofs by fid */
   FNameUserNameProofByFid = 27,
+
+  /* Used to index reactions by target */
+  TagsByTarget = 28,
 }
 
 /**

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -136,6 +136,9 @@ export enum UserPostfix {
 
   /* Link Compact State set */
   LinkCompactStateMessage = 100,
+
+  /* Tag */
+  TagMessage = 101,
 }
 
 export enum OnChainEventPostfix {
@@ -160,4 +163,5 @@ export type UserMessagePostfix =
   | UserPostfix.ReactionMessage
   | UserPostfix.UserDataMessage
   | UserPostfix.UsernameProofMessage
+  | UserPostfix.TagMessage
   | UserPostfix.LinkCompactStateMessage;

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -143,6 +143,10 @@ export enum UserPostfix {
 
   /* Link Compact State set */
   LinkCompactStateMessage = 100,
+
+  /** TagStore add and remove sets */
+  TagAdds = 101,
+  TagRemoves = 102,
 }
 
 export enum OnChainEventPostfix {

--- a/apps/hubble/src/storage/stores/tagStore.test.ts
+++ b/apps/hubble/src/storage/stores/tagStore.test.ts
@@ -21,7 +21,7 @@ import { UserPostfix } from "../db/types.js";
 import { ResultAsync } from "neverthrow";
 import RocksDB from "storage/db/rocksdb.js";
 import { RustStoreBase } from "./rustStoreBase.js";
-import { messageDecode } from "../../storage/db/message.js";
+import { messageDecode } from "../db/message.js";
 
 class TagStore extends RustStoreBase<TagAddMessage, TagRemoveMessage> {
   constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {

--- a/apps/hubble/src/storage/stores/tagStore.ts
+++ b/apps/hubble/src/storage/stores/tagStore.ts
@@ -1,0 +1,142 @@
+import {
+  CastId,
+  Message,
+  TagAddMessage,
+  TagRemoveMessage,
+  StoreType,
+  getDefaultStoreLimit,
+} from "@farcaster/hub-nodejs";
+import {
+  rsCreateReactionStore,
+  rsGetReactionAdd,
+  rsGetReactionAddsByFid,
+  rsGetReactionRemove,
+  rsGetReactionRemovesByFid,
+  rsGetReactionsByTarget,
+  rustErrorToHubError,
+} from "../../rustfunctions.js";
+import StoreEventHandler from "./storeEventHandler.js";
+import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
+import { UserPostfix } from "../db/types.js";
+import { ResultAsync } from "neverthrow";
+import RocksDB from "storage/db/rocksdb.js";
+import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
+
+class ReactionStore extends RustStoreBase<ReactionAddMessage, ReactionRemoveMessage> {
+  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
+    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.REACTIONS);
+    const rustReactionStore = rsCreateReactionStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
+
+    super(db, rustReactionStore, UserPostfix.ReactionMessage, eventHandler, pruneSizeLimit);
+  }
+
+  async getReactionAdd(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionAddMessage> {
+    let targetCastId = Buffer.from([]);
+    let targetUrl = "";
+
+    if (typeof target === "string") {
+      targetUrl = target;
+    } else {
+      targetCastId = Buffer.from(CastId.encode(target).finish());
+    }
+
+    const result = await ResultAsync.fromPromise(
+      rsGetReactionAdd(this._rustStore, fid, type, targetCastId, targetUrl),
+      rustErrorToHubError,
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return messageDecode(new Uint8Array(result.value)) as ReactionAddMessage;
+  }
+
+  async getReactionRemove(fid: number, type: ReactionType, target: CastId | string): Promise<ReactionRemoveMessage> {
+    let targetCastId = Buffer.from([]);
+    let targetUrl = "";
+
+    if (typeof target === "string") {
+      targetUrl = target;
+    } else {
+      targetCastId = Buffer.from(CastId.encode(target).finish());
+    }
+
+    const result = await ResultAsync.fromPromise(
+      rsGetReactionRemove(this._rustStore, fid, type, targetCastId, targetUrl),
+      rustErrorToHubError,
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return messageDecode(new Uint8Array(result.value)) as ReactionRemoveMessage;
+  }
+
+  async getReactionAddsByFid(
+    fid: number,
+    type?: ReactionType,
+    pageOptions?: PageOptions,
+  ): Promise<MessagesPage<ReactionAddMessage>> {
+    const messages_page = await rsGetReactionAddsByFid(this._rustStore, fid, type ?? 0, pageOptions ?? {});
+
+    const messages =
+      messages_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionAddMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: messages_page.nextPageToken };
+  }
+
+  async getReactionRemovesByFid(
+    fid: number,
+    type?: ReactionType,
+    pageOptions?: PageOptions,
+  ): Promise<MessagesPage<ReactionRemoveMessage>> {
+    const message_page = await rsGetReactionRemovesByFid(this._rustStore, fid, type ?? 0, pageOptions ?? {});
+
+    const messages =
+      message_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionRemoveMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: message_page.nextPageToken };
+  }
+
+  async getAllReactionMessagesByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+  ): Promise<MessagesPage<ReactionAddMessage | ReactionRemoveMessage>> {
+    return await this.getAllMessagesByFid(fid, pageOptions);
+  }
+
+  async getReactionsByTarget(
+    target: CastId | string,
+    type?: ReactionType,
+    pageOptions: PageOptions = {},
+  ): Promise<MessagesPage<ReactionAddMessage>> {
+    let targetCastId = Buffer.from([]);
+    let targetUrl = "";
+
+    if (typeof target === "string") {
+      targetUrl = target;
+    } else {
+      targetCastId = Buffer.from(CastId.encode(target).finish());
+    }
+
+    const message_page = await rsGetReactionsByTarget(
+      this._rustStore,
+      targetCastId,
+      targetUrl,
+      type ?? ReactionType.NONE,
+      pageOptions,
+    );
+
+    const messages =
+      message_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as ReactionAddMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: message_page.nextPageToken };
+  }
+}
+
+export default ReactionStore;

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -235,7 +235,7 @@ export const makeTagAdd = async (
   body: protobufs.TagBody,
   dataOptions: MessageDataOptions,
   signer: Signer,
-): HubAsyncResult<protobufs.ReactionAddMessage> => {
+): HubAsyncResult<protobufs.TagAddMessage> => {
   const data = await makeTagAddData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);
@@ -247,7 +247,7 @@ export const makeTagRemove = async (
   body: protobufs.TagBody,
   dataOptions: MessageDataOptions,
   signer: Signer,
-): HubAsyncResult<protobufs.ReactionRemoveMessage> => {
+): HubAsyncResult<protobufs.TagRemoveMessage> => {
   const data = await makeTagRemoveData(body, dataOptions);
   if (data.isErr()) {
     return err(data.error);

--- a/packages/core/src/protobufs/generated/message.ts
+++ b/packages/core/src/protobufs/generated/message.ts
@@ -499,7 +499,7 @@ export interface ReactionBody {
 /** Adds or removes a Tag from a Cast */
 export interface TagBody {
   /** Tag value */
-  value: string;
+  type: string;
   /** CastId of the Cast to react to */
   targetCastId?:
     | CastId
@@ -1570,13 +1570,13 @@ export const ReactionBody = {
 };
 
 function createBaseTagBody(): TagBody {
-  return { value: "", targetCastId: undefined, targetUrl: undefined };
+  return { type: "", targetCastId: undefined, targetUrl: undefined };
 }
 
 export const TagBody = {
   encode(message: TagBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.value !== "") {
-      writer.uint32(10).string(message.value);
+    if (message.type !== "") {
+      writer.uint32(10).string(message.type);
     }
     if (message.targetCastId !== undefined) {
       CastId.encode(message.targetCastId, writer.uint32(18).fork()).ldelim();
@@ -1599,7 +1599,7 @@ export const TagBody = {
             break;
           }
 
-          message.value = reader.string();
+          message.type = reader.string();
           continue;
         case 2:
           if (tag != 18) {
@@ -1626,7 +1626,7 @@ export const TagBody = {
 
   fromJSON(object: any): TagBody {
     return {
-      value: isSet(object.value) ? String(object.value) : "",
+      type: isSet(object.type) ? String(object.type) : "",
       targetCastId: isSet(object.targetCastId) ? CastId.fromJSON(object.targetCastId) : undefined,
       targetUrl: isSet(object.targetUrl) ? String(object.targetUrl) : undefined,
     };
@@ -1634,7 +1634,7 @@ export const TagBody = {
 
   toJSON(message: TagBody): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    message.type !== undefined && (obj.type = message.type);
     message.targetCastId !== undefined &&
       (obj.targetCastId = message.targetCastId ? CastId.toJSON(message.targetCastId) : undefined);
     message.targetUrl !== undefined && (obj.targetUrl = message.targetUrl);
@@ -1647,7 +1647,7 @@ export const TagBody = {
 
   fromPartial<I extends Exact<DeepPartial<TagBody>, I>>(object: I): TagBody {
     const message = createBaseTagBody();
-    message.value = object.value ?? "";
+    message.type = object.type ?? "";
     message.targetCastId = (object.targetCastId !== undefined && object.targetCastId !== null)
       ? CastId.fromPartial(object.targetCastId)
       : undefined;

--- a/packages/core/src/validations.ts
+++ b/packages/core/src/validations.ts
@@ -629,6 +629,16 @@ export const validateReactionType = (type: number): HubResult<protobufs.Reaction
   return ok(type);
 };
 
+// VIC-TODO: determine reasonable max tag value size (probably > 8)
+export const validateTagValueType = (type: string): HubResult<string> => {
+  const typeBuffer = Buffer.from(type);
+  if (type.length === 0 || typeBuffer.length > 8) {
+    return err(new HubError("bad_request.validation_failure", "value must be between 1-8 bytes"));
+  }
+
+  return ok(type);
+};
+
 export const validateTarget = (
   target: protobufs.CastId | string | number,
 ): HubResult<protobufs.CastId | string | number> => {
@@ -713,7 +723,7 @@ export const validateReactionBody = (body: protobufs.ReactionBody): HubResult<pr
 };
 
 export const validateTagBody = (body: protobufs.TagBody): HubResult<protobufs.TagBody> => {
-  const validatedType = ok(body.value); // VIC-TODO: proper string validation
+  const validatedType = validateTagValueType(body.type);
   if (validatedType.isErr()) {
     return err(validatedType.error);
   }

--- a/packages/hub-nodejs/src/generated/message.ts
+++ b/packages/hub-nodejs/src/generated/message.ts
@@ -499,7 +499,7 @@ export interface ReactionBody {
 /** Adds or removes a Tag from a Cast */
 export interface TagBody {
   /** Tag value */
-  value: string;
+  type: string;
   /** CastId of the Cast to react to */
   targetCastId?:
     | CastId
@@ -1570,13 +1570,13 @@ export const ReactionBody = {
 };
 
 function createBaseTagBody(): TagBody {
-  return { value: "", targetCastId: undefined, targetUrl: undefined };
+  return { type: "", targetCastId: undefined, targetUrl: undefined };
 }
 
 export const TagBody = {
   encode(message: TagBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.value !== "") {
-      writer.uint32(10).string(message.value);
+    if (message.type !== "") {
+      writer.uint32(10).string(message.type);
     }
     if (message.targetCastId !== undefined) {
       CastId.encode(message.targetCastId, writer.uint32(18).fork()).ldelim();
@@ -1599,7 +1599,7 @@ export const TagBody = {
             break;
           }
 
-          message.value = reader.string();
+          message.type = reader.string();
           continue;
         case 2:
           if (tag != 18) {
@@ -1626,7 +1626,7 @@ export const TagBody = {
 
   fromJSON(object: any): TagBody {
     return {
-      value: isSet(object.value) ? String(object.value) : "",
+      type: isSet(object.type) ? String(object.type) : "",
       targetCastId: isSet(object.targetCastId) ? CastId.fromJSON(object.targetCastId) : undefined,
       targetUrl: isSet(object.targetUrl) ? String(object.targetUrl) : undefined,
     };
@@ -1634,7 +1634,7 @@ export const TagBody = {
 
   toJSON(message: TagBody): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    message.type !== undefined && (obj.type = message.type);
     message.targetCastId !== undefined &&
       (obj.targetCastId = message.targetCastId ? CastId.toJSON(message.targetCastId) : undefined);
     message.targetUrl !== undefined && (obj.targetUrl = message.targetUrl);
@@ -1647,7 +1647,7 @@ export const TagBody = {
 
   fromPartial<I extends Exact<DeepPartial<TagBody>, I>>(object: I): TagBody {
     const message = createBaseTagBody();
-    message.value = object.value ?? "";
+    message.type = object.type ?? "";
     message.targetCastId = (object.targetCastId !== undefined && object.targetCastId !== null)
       ? CastId.fromPartial(object.targetCastId)
       : undefined;

--- a/packages/hub-nodejs/src/scripts/test.ts
+++ b/packages/hub-nodejs/src/scripts/test.ts
@@ -34,9 +34,6 @@ const NETWORK = FarcasterNetwork.DEVNET; // Network of the Hub
   // If your client does not use SSL.
   const client = getInsecureHubRpcClient(HUB_URL);
 
-  const f = await client.getFids({});
-  console.log(f);
-
   /**
    * Example 1: A cast with no mentions
    *
@@ -57,21 +54,18 @@ const NETWORK = FarcasterNetwork.DEVNET; // Network of the Hub
 
   const cast = await client.submitMessage(castAdd._unsafeUnwrap());
 
-  console.log(JSON.stringify(cast));
+  console.log(JSON.stringify(cast, null, 2));
 
   const tagAdd = await makeTagAdd({
       value: 'testTag',
-      targetCastId: {
-        fid: cast.fid,
-        hash: cast.hash,
-      },
+      targetUrl: 'test',
     },
   dataOptions,
   ed25519Signer);
 
-  const tag = await client.submitMessage(await tagAdd._unsafeUnwrap());
+  const tag = await client.submitMessage(tagAdd._unsafeUnwrap());
 
-  console.log('TAG!!!!', tag);
+  console.log('TAG!!!!', JSON.stringify(tag, null, 2));
 
   const y = await client.getCastsByFid({ fid: FID });
 

--- a/packages/hub-nodejs/src/scripts/test.ts
+++ b/packages/hub-nodejs/src/scripts/test.ts
@@ -54,10 +54,10 @@ const NETWORK = FarcasterNetwork.DEVNET; // Network of the Hub
 
   const cast = await client.submitMessage(castAdd._unsafeUnwrap());
 
-  console.log(JSON.stringify(cast, null, 2));
+  // console.log(JSON.stringify(cast, null, 2));
 
   const tagAdd = await makeTagAdd({
-      value: 'testTag',
+      type: 'testTag',
       targetUrl: 'test',
     },
   dataOptions,
@@ -65,7 +65,7 @@ const NETWORK = FarcasterNetwork.DEVNET; // Network of the Hub
 
   const tag = await client.submitMessage(tagAdd._unsafeUnwrap());
 
-  console.log('TAG!!!!', JSON.stringify(tag, null, 2));
+  console.log(JSON.stringify(tag, null, 2));
 
   const y = await client.getCastsByFid({ fid: FID });
 

--- a/packages/hub-web/src/generated/message.ts
+++ b/packages/hub-web/src/generated/message.ts
@@ -499,7 +499,7 @@ export interface ReactionBody {
 /** Adds or removes a Tag from a Cast */
 export interface TagBody {
   /** Tag value */
-  value: string;
+  type: string;
   /** CastId of the Cast to react to */
   targetCastId?:
     | CastId
@@ -1570,13 +1570,13 @@ export const ReactionBody = {
 };
 
 function createBaseTagBody(): TagBody {
-  return { value: "", targetCastId: undefined, targetUrl: undefined };
+  return { type: "", targetCastId: undefined, targetUrl: undefined };
 }
 
 export const TagBody = {
   encode(message: TagBody, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.value !== "") {
-      writer.uint32(10).string(message.value);
+    if (message.type !== "") {
+      writer.uint32(10).string(message.type);
     }
     if (message.targetCastId !== undefined) {
       CastId.encode(message.targetCastId, writer.uint32(18).fork()).ldelim();
@@ -1599,7 +1599,7 @@ export const TagBody = {
             break;
           }
 
-          message.value = reader.string();
+          message.type = reader.string();
           continue;
         case 2:
           if (tag != 18) {
@@ -1626,7 +1626,7 @@ export const TagBody = {
 
   fromJSON(object: any): TagBody {
     return {
-      value: isSet(object.value) ? String(object.value) : "",
+      type: isSet(object.type) ? String(object.type) : "",
       targetCastId: isSet(object.targetCastId) ? CastId.fromJSON(object.targetCastId) : undefined,
       targetUrl: isSet(object.targetUrl) ? String(object.targetUrl) : undefined,
     };
@@ -1634,7 +1634,7 @@ export const TagBody = {
 
   toJSON(message: TagBody): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    message.type !== undefined && (obj.type = message.type);
     message.targetCastId !== undefined &&
       (obj.targetCastId = message.targetCastId ? CastId.toJSON(message.targetCastId) : undefined);
     message.targetUrl !== undefined && (obj.targetUrl = message.targetUrl);
@@ -1647,7 +1647,7 @@ export const TagBody = {
 
   fromPartial<I extends Exact<DeepPartial<TagBody>, I>>(object: I): TagBody {
     const message = createBaseTagBody();
-    message.value = object.value ?? "";
+    message.type = object.type ?? "";
     message.targetCastId = (object.targetCastId !== undefined && object.targetCastId !== null)
       ? CastId.fromPartial(object.targetCastId)
       : undefined;

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -145,7 +145,7 @@ message ReactionBody {
 
 /** Adds or removes a Tag from a Cast */
 message TagBody {
-  string value = 1; // Tag value
+  string type = 1; // Tag value
   oneof target {
     CastId target_cast_id = 2; // CastId of the Cast to react to
     string target_url = 3; // URL to react to


### PR DESCRIPTION
### Rust TODOs
- [ ] Make value optional in the rust code db access functions (it's optional in JS)
- [ ] Convert `u8` key portion of the tags that was due to reaction types to a hash (reuse `blake3_20` in `utils.js`)

###  TS Missing Implementations
- [ ] Hubble HTTP endpoints (`apps/hubble/src/rpc/httpServer.ts`)
- [ ] Hubble RPC endpoints (`apps/hubble/src/rpc/server.ts`)

### TS Missing Tests
- [ ] Hubble service tests (`apps/hubble/src/rpc/test/reactionService.test.ts`)