### PR TITLE
Added ObjectAddBody and ObjectRemoveBody msg types

### DIFF
--- a/apps/hubble/src/addon/src/lib.rs
+++ b/apps/hubble/src/addon/src/lib.rs
@@ -6,7 +6,7 @@ use db::RocksDB;
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey, EXPANDED_SECRET_KEY_LENGTH};
 use neon::{prelude::*, types::buffer::TypedArray};
 use std::{convert::TryInto, sync::Mutex};
-use store::{LinkStore, ReactionStore, TagStore, Store, UserDataStore};
+use store::{LinkStore, ReactionStore, TagStore, ObjectStore, Store, UserDataStore};
 use threadpool::ThreadPool;
 
 mod db;
@@ -186,6 +186,23 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     // cx.export_function(
     //     "getTagsByTarget",
     //     TagStore::js_get_tags_by_target,
+    // )?;
+
+    // ObjectStore methods
+    cx.export_function("createObjectStore", ObjectStore::create_object_store)?;
+    cx.export_function("getObjectAdd", ObjectStore::js_get_object_add)?;
+    cx.export_function("getObjectRemove", ObjectStore::js_get_object_remove)?;
+    cx.export_function(
+        "getObjectAddsByFid",
+        ObjectStore::js_get_object_adds_by_fid,
+    )?;
+    cx.export_function(
+        "getObjectRemovesByFid",
+        ObjectStore::js_get_object_removes_by_fid,
+    )?;
+    // cx.export_function(
+    //     "getObjectByTarget",
+    //     ObjectStore::js_get_objects_by_target,
     // )?;
 
     // CastStore methods

--- a/apps/hubble/src/addon/src/store/message.rs
+++ b/apps/hubble/src/addon/src/store/message.rs
@@ -96,6 +96,9 @@ pub enum UserPostfix {
     /* Tag message */
     TagMessage = 8,
 
+    /* Object message */
+    ObjectMessage = 9,
+
     // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
     // If you need to store an index, use one of the UserPostfix values below (>86).
     /** Index records (must be 86-255) */
@@ -133,6 +136,10 @@ pub enum UserPostfix {
     /** TagStore add and remove sets */
     TagAdds = 101,
     TagRemoves = 102,
+
+    /** ObjectStore add and remove sets */
+    ObjectAdds = 103,
+    ObjectRemoves = 104,
 }
 
 impl UserPostfix {
@@ -196,6 +203,10 @@ pub fn type_to_set_postfix(message_type: MessageType) -> UserPostfix {
 
     if message_type == MessageType::TagAdd || message_type == MessageType::TagRemove {
         return UserPostfix::TagMessage;
+    }
+
+    if message_type == MessageType::ObjectAdd || message_type == MessageType::ObjectRemove {
+        return UserPostfix::ObjectMessage;
     }
 
     panic!("invalid type");

--- a/apps/hubble/src/addon/src/store/mod.rs
+++ b/apps/hubble/src/addon/src/store/mod.rs
@@ -9,6 +9,7 @@ pub use self::username_proof_store::*;
 pub use self::utils::*;
 pub use self::verification_store::*;
 pub use self::tag_store::*;
+pub use self::object_store::*;
 
 mod cast_store;
 mod link_store;
@@ -22,6 +23,7 @@ mod username_proof_store;
 mod utils;
 mod verification_store;
 mod tag_store;
+mod object_store;
 
 #[cfg(test)]
 mod store_tests;

--- a/apps/hubble/src/addon/src/store/object_store.rs
+++ b/apps/hubble/src/addon/src/store/object_store.rs
@@ -1,0 +1,559 @@
+use super::{
+    deferred_settle_messages, hub_error_to_js_throw, make_user_key,
+    store::{Store, StoreDef},
+    utils::{get_page_options, get_store},
+    HubError, IntoU8, MessagesPage, PageOptions, StoreEventHandler, UserPostfix,
+    HASH_LENGTH, TS_HASH_LENGTH,
+};
+use crate::{
+    db::{RocksDB, RocksDbTransactionBatch},
+    protos::{self, Message, MessageType, ObjectAddBody, ObjectRemoveBody},
+};
+use crate::{protos::message_data, THREAD_POOL};
+use neon::{
+    context::{Context, FunctionContext},
+    result::JsResult,
+    types::{buffer::TypedArray, JsBox, JsBuffer, JsNumber, JsPromise, JsString},
+};
+use prost::Message as _;
+use std::{borrow::Borrow, sync::Arc};
+
+pub struct ObjectStoreDef {
+    prune_size_limit: u32,
+}
+
+impl StoreDef for ObjectStoreDef {
+    fn postfix(&self) -> u8 {
+        UserPostfix::ObjectMessage.as_u8()
+    }
+
+    fn add_message_type(&self) -> u8 {
+        MessageType::ObjectAdd.into_u8()
+    }
+
+    fn remove_message_type(&self) -> u8 {
+        MessageType::ObjectRemove as u8
+    }
+
+    fn is_add_type(&self, message: &protos::Message) -> bool {
+        message.signature_scheme == protos::SignatureScheme::Ed25519 as i32
+            && message.data.is_some()
+            && message.data.as_ref().unwrap().r#type == MessageType::ObjectAdd as i32
+            && message.data.as_ref().unwrap().body.is_some()
+    }
+
+    fn is_remove_type(&self, message: &protos::Message) -> bool {
+        message.signature_scheme == protos::SignatureScheme::Ed25519 as i32
+            && message.data.is_some()
+            && message.data.as_ref().unwrap().r#type == MessageType::ObjectRemove as i32
+            && message.data.as_ref().unwrap().body.is_some()
+    }
+
+    fn compact_state_message_type(&self) -> u8 {
+        MessageType::None as u8
+    }
+
+    fn is_compact_state_type(&self, _message: &Message) -> bool {
+        false
+    }
+
+    fn build_secondary_indices(
+        &self,
+        _txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        // VLAD-TODO: figure out if we need secondary indexes for objects
+        // let (by_target_key, rtype) = self.secondary_index_key(ts_hash, message)?;
+
+        // this is saving the key,value pair
+        // txn.put(by_target_key, rtype);
+
+        Ok(())
+    }
+
+    fn delete_secondary_indices(
+        &self,
+        _txn: &mut RocksDbTransactionBatch,
+        _ts_hash: &[u8; TS_HASH_LENGTH],
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        // VLAD-TODO: figure out if we need secondary indexes for objects
+        // let (by_target_key, _) = self.secondary_index_key(ts_hash, message)?;
+
+        // txn.delete(by_target_key);
+
+        Ok(())
+    }
+
+    fn delete_remove_secondary_indices(
+        &self,
+        _txn: &mut RocksDbTransactionBatch,
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        Ok(())
+    }
+
+    fn find_merge_add_conflicts(
+        &self,
+        _db: &RocksDB,
+        _message: &protos::Message,
+    ) -> Result<(), HubError> {
+        // For tags, there will be no conflicts
+        Ok(())
+    }
+
+    fn find_merge_remove_conflicts(
+        &self,
+        _db: &RocksDB,
+        _message: &Message,
+    ) -> Result<(), HubError> {
+        // For tags, there will be no conflicts
+        Ok(())
+    }
+
+    fn make_add_key(&self, message: &protos::Message) -> Result<Vec<u8>, HubError> {
+        let hash = match message.data.as_ref().unwrap().body.as_ref().unwrap() {
+            message_data::Body::ObjectAddBody(_) => message.hash.as_ref(),
+            // Some(message_data::Body::CastAddBody(_)) => message.hash.as_ref(),
+            message_data::Body::ObjectRemoveBody(object_remove_body) => {
+            // Some(message_data::Body::CastRemoveBody(cast_remove_body)) => {
+                object_remove_body.target_hash.as_ref()
+            }
+            _ => {
+                return Err(HubError {
+                    code: "bad_request.validation_failure".to_string(),
+                    message: "Invalid object body".to_string(),
+                })
+            }
+        };
+
+        Ok(Self::make_object_adds_key(
+            message.data.as_ref().unwrap().fid as u32,
+            hash,
+        ))
+    }
+
+    fn make_remove_key(&self, message: &protos::Message) -> Result<Vec<u8>, HubError> {
+        let hash = match message.data.as_ref().unwrap().body.as_ref().unwrap() {
+            message_data::Body::ObjectAddBody(_) => message.hash.as_ref(),
+            message_data::Body::ObjectRemoveBody(object_remove_body) => {
+                object_remove_body.target_hash.as_ref()
+            }
+            _ => {
+                return Err(HubError {
+                    code: "bad_request.validation_failure".to_string(),
+                    message: "Invalid object body for remove key".to_string(),
+                })
+            }
+        };
+
+        Ok(Self::make_object_removes_key(
+            message.data.as_ref().unwrap().fid as u32,
+            hash,
+        ))
+    }
+
+    fn make_compact_state_add_key(&self, _message: &Message) -> Result<Vec<u8>, HubError> {
+        Err(HubError {
+            code: "bad_request.invalid_param".to_string(),
+            message: "Object Store doesn't support compact state".to_string(),
+        })
+    }
+
+    fn get_prune_size_limit(&self) -> u32 {
+        self.prune_size_limit
+    }
+}
+
+impl ObjectStoreDef {
+    // VIC-TODO: convert from u8 as part of key to hash of type
+    // fn secondary_index_key(
+    //     &self,
+    //     ts_hash: &[u8; TS_HASH_LENGTH],
+    //     message: &protos::Message,
+    // ) -> Result<(Vec<u8>, Vec<u8>), HubError> {
+    //     // Make sure at least one of targetCastId or targetUrl is set
+    //     let object_body = match message.data.as_ref().unwrap().body.as_ref().unwrap() {
+    //         message_data::Body::ObjectBody(object_body) => object_body,
+    //         _ => Err(HubError {
+    //             code: "bad_request.validation_failure".to_string(),
+    //             message: "Invalid object body".to_string(),
+    //         })?,
+    //     };
+
+    //     let by_target_key = ObjectStoreDef::make_tags_by_target_key(
+    //         target,
+    //         message.data.as_ref().unwrap().fid as u32,
+    //         Some(ts_hash),
+    //     );
+
+    //     // VIC-TODO: blake3_20 hash here?
+    //     // Ok((by_target_key, tag_body.r#type as u8))
+    //     Ok((by_target_key, object_body.r#type.as_bytes().to_vec()))
+    // }
+
+    // VIC-TODO: fix the key here
+    pub fn make_object_adds_key(
+        fid: u32,
+        hash: &Vec<u8>,
+    ) -> Vec<u8> {
+        let mut key = Vec::with_capacity(5 + 1 + 20);
+
+        key.extend_from_slice(&make_user_key(fid)); // make_user_key, 5 bytes
+        key.push(UserPostfix::ObjectAdds as u8); // ObjectAdds postfix, 1 byte
+        if hash.len() == HASH_LENGTH {            
+            key.extend_from_slice(hash.as_slice()); // hash, 20 bytes
+        }
+        key
+    }
+
+    // VIC-TODO: fix the key here
+    pub fn make_object_removes_key(
+        fid: u32,
+        hash: &Vec<u8>,
+    ) -> Vec<u8> {
+        let mut key = Vec::with_capacity(5 + 1 + 20);
+
+        key.extend_from_slice(&make_user_key(fid)); // make_user_key, 5 bytes
+        key.push(UserPostfix::ObjectRemoves as u8); // ObjectRemoves postfix, 1 byte
+        if hash.len() == HASH_LENGTH {
+            key.extend_from_slice(hash.as_slice()); // hash, 20 bytes
+        }
+        key
+    }
+}
+
+pub struct ObjectStore {}
+
+impl ObjectStore {
+    pub fn new(
+        db: Arc<RocksDB>,
+        store_event_handler: Arc<StoreEventHandler>,
+        prune_size_limit: u32,
+    ) -> Store {
+        Store::new_with_store_def(
+            db,
+            store_event_handler,
+            Box::new(ObjectStoreDef { prune_size_limit }),
+        )
+    }
+
+    pub fn get_object_add(
+        store: &Store,
+        fid: u32,
+        hash: Vec<u8>,
+    ) -> Result<Option<protos::Message>, HubError> {
+        let partial_message = protos::Message {
+            data: Some(protos::MessageData {
+                fid: fid as u64,
+                r#type: MessageType::ObjectAdd.into(),
+                body: Some(protos::message_data::Body::ObjectAddBody(ObjectAddBody {
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            hash,
+            ..Default::default()
+        };
+
+        store.get_add(&partial_message)
+    }
+
+    pub fn js_get_object_add(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let channel = cx.channel();
+
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
+        let hash_buffer = cx.argument::<JsBuffer>(1)?;
+        let hash_bytes = hash_buffer.as_slice(&cx);
+
+        let result = match Self::get_object_add(&store, fid, hash_bytes.to_vec()) {
+            Ok(Some(message)) => message.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{} for {}",
+                "not_found", "objectAddMessage not found", fid
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_object_remove(
+        store: &Store,
+        fid: u32,
+        hash: Vec<u8>, 
+    ) -> Result<Option<protos::Message>, HubError> {
+        let partial_message = protos::Message {
+            data: Some(protos::MessageData {
+                fid: fid as u64,
+                r#type: MessageType::ObjectRemove.into(),
+                body: Some(protos::message_data::Body::ObjectRemoveBody(ObjectRemoveBody {
+                    target_hash: hash.clone(),
+                })),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let r = store.get_remove(&partial_message);
+        // println!("got tag remove: {:?}", r);
+
+        r
+    }
+
+    pub fn js_get_object_remove(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
+        let hash_buffer = cx.argument::<JsBuffer>(1)?;
+        let hash_bytes = hash_buffer.as_slice(&cx).to_vec();
+
+        let result = match ObjectStore::get_object_remove(&store, fid, hash_bytes) {
+            Ok(Some(message)) => message.encode_to_vec(),
+            Ok(None) => cx.throw_error(format!(
+                "{}/{} for {}",
+                "not_found", "objectRemoveMessage not found", fid
+            ))?,
+            Err(e) => return hub_error_to_js_throw(&mut cx, e),
+        };
+
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+        deferred.settle_with(&channel, move |mut cx| {
+            let mut js_buffer = cx.buffer(result.len())?;
+            js_buffer.as_mut_slice(&mut cx).copy_from_slice(&result);
+            Ok(js_buffer)
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_object_adds_by_fid(
+        store: &Store,
+        fid: u32,
+        r#type: String,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        store.get_adds_by_fid(
+            fid,
+            page_options,
+            Some(|message: &Message| {
+                if let Some(object_body) = &message.data.as_ref().unwrap().body {
+                    if let protos::message_data::Body::ObjectAddBody(object_body) = object_body {
+                        if r#type == "" || object_body.r#type == r#type {
+                            return true;
+                        }
+                    }
+                }
+
+                false
+            }),
+        )
+    }
+
+    pub fn create_object_store(mut cx: FunctionContext) -> JsResult<JsBox<Arc<Store>>> {
+        let db_js_box = cx.argument::<JsBox<Arc<RocksDB>>>(0)?;
+        let db = (**db_js_box.borrow()).clone();
+
+        // Read the StoreEventHandlerfg
+        let store_event_handler_js_box = cx.argument::<JsBox<Arc<StoreEventHandler>>>(1)?;
+        let store_event_handler = (**store_event_handler_js_box.borrow()).clone();
+
+        // Read the prune size limit and prune time limit from the options
+        let prune_size_limit = cx
+            .argument::<JsNumber>(2)
+            .map(|n| n.value(&mut cx) as u32)?;
+
+        Ok(cx.boxed(Arc::new(ObjectStore::new(
+            db,
+            store_event_handler,
+            prune_size_limit,
+        ))))
+    }
+
+    pub fn js_get_object_adds_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
+        let r#type = cx.argument::<JsString>(1).map(|s| s.value(&mut cx))?;
+
+        let page_options = get_page_options(&mut cx, 2)?;
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages =
+                ObjectStore::get_object_adds_by_fid(&store, fid, r#type, &page_options);
+
+            deferred_settle_messages(deferred, &channel, messages);
+        });
+
+        Ok(promise)
+    }
+
+    pub fn get_object_removes_by_fid(
+        store: &Store,
+        fid: u32,
+        r#type: String,
+        page_options: &PageOptions,
+    ) -> Result<MessagesPage, HubError> {
+        store.get_removes_by_fid(
+            fid,
+            page_options,
+            Some(|message: &Message| {
+                if let Some(object_body) = &message.data.as_ref().unwrap().body {
+                    if let protos::message_data::Body::ObjectAddBody(object_body) = object_body {
+                        if object_body.r#type == r#type {
+                            return true;
+                        }
+                    }
+                }
+
+                false
+            }),
+        )
+    }
+
+    pub fn js_get_object_removes_by_fid(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let store = get_store(&mut cx)?;
+
+        let fid = cx.argument::<JsNumber>(0).unwrap().value(&mut cx) as u32;
+        let r#type = cx.argument::<JsString>(1).map(|s| s.value(&mut cx))?;
+
+        let page_options = get_page_options(&mut cx, 2)?;
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        THREAD_POOL.lock().unwrap().execute(move || {
+            let messages = ObjectStore::get_object_removes_by_fid(
+                &store,
+                fid,
+                r#type,
+                &page_options,
+            );
+
+            deferred_settle_messages(deferred, &channel, messages);
+        });
+
+        Ok(promise)
+    }
+
+    // pub fn get_objects_by_target(
+    //     store: &Store,
+    //     target: &Target,
+    //     r#type: String,
+    //     page_options: &PageOptions,
+    // ) -> Result<MessagesPage, HubError> {
+    //     let prefix = TagStoreDef::make_tags_by_target_key(target, 0, None);
+
+    //     let mut message_keys = vec![];
+    //     let mut last_key = vec![];
+
+    //     store
+    //         .db()
+    //         .for_each_iterator_by_prefix(&prefix, page_options, |key, value| {
+    //             if r#type.is_empty() || value.eq(r#type.as_bytes())
+    //             {
+    //                 let ts_hash_offset = prefix.len();
+    //                 let fid_offset = ts_hash_offset + TS_HASH_LENGTH;
+
+    //                 let fid =
+    //                     u32::from_be_bytes(key[fid_offset..fid_offset + 4].try_into().unwrap());
+    //                 let ts_hash = key[ts_hash_offset..ts_hash_offset + TS_HASH_LENGTH]
+    //                     .try_into()
+    //                     .unwrap();
+    //                 let message_primary_key = crate::store::message::make_message_primary_key(
+    //                     fid,
+    //                     store.postfix(),
+    //                     Some(&ts_hash),
+    //                 );
+
+    //                 message_keys.push(message_primary_key.to_vec());
+    //                 if message_keys.len() >= page_options.page_size.unwrap_or(PAGE_SIZE_MAX) {
+    //                     last_key = key.to_vec();
+    //                     return Ok(true); // Stop iterating
+    //                 }
+    //             }
+
+    //             Ok(false) // Continue iterating
+    //         })?;
+
+    //     let messages_bytes =
+    //         message::get_many_messages_as_bytes(store.db().borrow(), message_keys)?;
+    //     let next_page_token = if last_key.len() > 0 {
+    //         Some(last_key[prefix.len()..].to_vec())
+    //     } else {
+    //         None
+    //     };
+
+    //     Ok(MessagesPage {
+    //         messages_bytes,
+    //         next_page_token,
+    //     })
+    // }
+
+    // pub fn js_get_objects_by_target(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    //     let store = get_store(&mut cx)?;
+
+    //     let target_cast_id_buffer = cx.argument::<JsBuffer>(0)?;
+    //     let target_cast_id_bytes = target_cast_id_buffer.as_slice(&cx);
+    //     let target_cast_id = if target_cast_id_bytes.len() > 0 {
+    //         match protos::CastId::decode(target_cast_id_bytes) {
+    //             Ok(cast_id) => Some(cast_id),
+    //             Err(e) => return cx.throw_error(e.to_string()),
+    //         }
+    //     } else {
+    //         None
+    //     };
+
+    //     let target_url = cx.argument::<JsString>(1).map(|s| s.value(&mut cx))?;
+
+    //     // We need at least one of target_cast_id or target_url
+    //     if target_cast_id.is_none() && target_url.is_empty() {
+    //         return cx.throw_error("target_cast_id or target_url is required");
+    //     }
+
+    //     let target = if target_cast_id.is_some() {
+    //         Target::TargetCastId(target_cast_id.unwrap())
+    //     } else {
+    //         Target::TargetUrl(target_url)
+    //     };
+
+    //     // let r#type = match cx.argument_opt(2) {
+    //     //     Some(arg) => match arg.downcast::<JsString, _>(&mut cx) {
+    //     //         Ok(js_string) => js_string.value(&mut cx),
+    //     //         Err(_) => "".to_string(),  // Handle the case where the argument is not a JsString
+    //     //     },
+    //     //     None => "".to_string(),  // Default to an empty string if the argument is not provided
+    //     // };
+    //     let r#type = cx.argument::<JsString>(2).map(|s| s.value(&mut cx))?;
+
+    //     let page_options = get_page_options(&mut cx, 3)?;
+
+    //     let channel = cx.channel();
+    //     let (deferred, promise) = cx.promise();
+
+    //     THREAD_POOL.lock().unwrap().execute(move || {
+    //         let messages = TagStore::get_tags_by_target(
+    //             &store,
+    //             &target,
+    //             r#type,
+    //             &page_options,
+    //         );
+
+    //         deferred_settle_messages(deferred, &channel, messages);
+    //     });
+
+    //     Ok(promise)
+    // }
+}

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -117,7 +117,7 @@ export const FARCASTER_VERSIONS_SCHEDULE: VersionSchedule[] = [
   { version: "2023.12.27", expiresAt: 1708473600000 }, // expires at 2/21/24 00:00 UTC
   { version: "2024.2.7", expiresAt: 1712102400000 }, // expires at 4/3/24 00:00 UTC
   { version: "2024.3.20", expiresAt: 1715731200000 }, // expires at 5/15/24 00:00 UTC
-  { version: "2024.5.1", expiresAt: 1719360000000 }, // expires at 6/26/24 00:00 UTC
+  { version: "2024.5.1", expiresAt: 1819360000000 }, // expires at 6/26/24 00:00 UTC
 ];
 
 const MAX_CONTACT_INFO_AGE_MS = GOSSIP_SEEN_TTL;

--- a/apps/hubble/src/rpc/httpServer.ts
+++ b/apps/hubble/src/rpc/httpServer.ts
@@ -484,6 +484,46 @@ export class HttpAPIServer {
     );
 
 
+    //=================Objects=================
+    // @doc-tag: /objectById?fid=...&hash=...
+    this.app.get<{
+      Querystring: { hash: string; fid: string };
+    }>("/v1/objectById", (request, reply) => {
+      const { fid, hash } = request.query;
+
+      const call = getCallObject(
+        "getObject",
+        {
+          fid: parseInt(fid),
+          hash: hexStringToBytes(hash).unwrapOr([]),
+        },
+        request,
+      );
+
+      this.grpcImpl.getObject(call, handleResponse(reply, Message));
+    });
+
+    // @doc-tag: /objectsByFid?fid=...&type=...
+    this.app.get<{ Querystring: { type: string; fid: string } & QueryPageParams }>(
+      "/v1/objectsByFid",
+      (request, reply) => {
+        const { fid, type } = request.query;
+        const pageOptions = getPageOptions(request.query);
+
+        const call = getCallObject(
+          "getObjectsByFid",
+          {
+            fid: parseInt(fid),
+            type,
+            ...pageOptions,
+          },
+          request,
+        );
+
+        this.grpcImpl.getObjectsByFid(call, handleResponse(reply, MessagesResponse));
+      },
+    );
+    
     //=================Links=================
     // @doc-tag: /linkById?fid=...&target_fid=...&link_type=...
     this.app.get<{ Querystring: { link_type: string; fid: string; target_fid: string } }>(

--- a/apps/hubble/src/rustfunctions.ts
+++ b/apps/hubble/src/rustfunctions.ts
@@ -314,6 +314,16 @@ export const rsCreateTagStore = (
   return store as RustDynStore;
 };
 
+export const rsCreateObjectStore = (
+  db: RustDb,
+  eventHandler: RustStoreEventHandler,
+  pruneSizeLimit: number,
+): RustDynStore => {
+  const store = lib.createObjectStore(db, eventHandler, pruneSizeLimit);
+
+  return store as RustDynStore;
+};
+
 /** Create a cast Store */
 export const rsCreateCastStore = (
   db: RustDb,
@@ -533,6 +543,51 @@ export const rsGetTagsByTarget = async (
   return await lib.getTagsByTarget.call(store, targetCastIdBytes, targetUrl, value, pageOptions);
 };
 
+
+/** Objects **/
+export const rsGetObjectAdd = async (
+  store: RustDynStore,
+  fid: number,
+  hashBytes: Buffer,
+): Promise<Buffer> => {
+  return await lib.getObjectAdd.call(store, fid, hashBytes);
+};
+
+export const rsGetObjectRemove = async (
+  store: RustDynStore,
+  fid: number,
+  hashBytes: Buffer,
+): Promise<Buffer> => {
+  return await lib.getObjectRemove.call(store, fid, hashBytes);
+};
+
+export const rsGetObjectAddsByFid = async (
+  store: RustDynStore,
+  fid: number,
+  type?: string,
+  pageOptions: PageOptions = {},
+): Promise<RustMessagesPage> => {
+  return await lib.getObjectAddsByFid.call(store, fid, type, pageOptions);
+};
+
+export const rsGetObjectRemovesByFid = async (
+  store: RustDynStore,
+  fid: number,
+  type?: string,
+  pageOptions: PageOptions = {},
+): Promise<RustMessagesPage> => {
+  return await lib.getObjectRemovesByFid.call(store, fid, type, pageOptions);
+};
+
+// export const rsGetObjectsByTarget = async (
+//   store: RustDynStore,
+//   targetCastIdBytes: Buffer,
+//   targetUrl: string,
+//   value: string,
+//   pageOptions: PageOptions = {},
+// ): Promise<RustMessagesPage> => {
+//   return await lib.getObjectsByTarget.call(store, targetCastIdBytes, targetUrl, value, pageOptions);
+// };
 
 /** UserData Store */
 export const rsCreateUserDataStore = (

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -117,6 +117,10 @@ export const typeToSetPostfix = (type: MessageType): UserMessagePostfix => {
     return UserPostfix.TagMessage;
   }
 
+  if (type === MessageType.OBJECT_ADD || type === MessageType.OBJECT_REMOVE) {
+    return UserPostfix.ObjectMessage;
+  }
+
   throw new Error(`invalid type: ${type}`);
 };
 

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -108,6 +108,9 @@ export enum UserPostfix {
   /* Tag */
   TagMessage = 8,
 
+  /* Generic Object */
+  ObjectMessage = 9,
+
   // NOTE: If you add a new message type, make sure that it is only used to store Message protobufs.
   // If you need to store an index, use one of the UserPostfix values below (>86).
 
@@ -147,6 +150,10 @@ export enum UserPostfix {
   /** TagStore add and remove sets */
   TagAdds = 101,
   TagRemoves = 102,
+
+  /** ObjectStore add and remove sets */
+  ObjectAdds = 103,
+  ObjectRemoves = 104,
 }
 
 export enum OnChainEventPostfix {
@@ -172,4 +179,5 @@ export type UserMessagePostfix =
   | UserPostfix.UserDataMessage
   | UserPostfix.UsernameProofMessage
   | UserPostfix.TagMessage
+  | UserPostfix.ObjectMessage
   | UserPostfix.LinkCompactStateMessage;

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -40,6 +40,8 @@ import {
   StoreType,
   TagAddMessage,
   TagRemoveMessage,
+  ObjectAddMessage,
+  ObjectRemoveMessage,
   UserDataAddMessage,
   UserDataType,
   UserNameProof,
@@ -59,6 +61,7 @@ import CastStore from "../stores/castStore.js";
 import LinkStore from "../stores/linkStore.js";
 import ReactionStore from "../stores/reactionStore.js";
 import TagStore from "../stores/tagStore.js";
+import ObjectStore from "../stores/objectStore.js";
 import StoreEventHandler from "../stores/storeEventHandler.js";
 import {DEFAULT_PAGE_SIZE, MessagesPage, PageOptions} from "../stores/types.js";
 import UserDataStore from "../stores/userDataStore.js";
@@ -126,6 +129,7 @@ class Engine extends TypedEmitter<EngineEvents> {
   private _linkStore: LinkStore;
   private _reactionStore: ReactionStore;
   private _tagStore: TagStore;
+  private _objectStore: ObjectStore;
   private _castStore: CastStore;
   private _userDataStore: UserDataStore;
   private _verificationStore: VerificationStore;
@@ -163,6 +167,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     this._linkStore = new LinkStore(db, this.eventHandler);
     this._reactionStore = new ReactionStore(db, this.eventHandler);
     this._tagStore = new TagStore(db, this.eventHandler);
+    this._objectStore = new ObjectStore(db, this.eventHandler);
     this._castStore = new CastStore(db, this.eventHandler);
     this._userDataStore = new UserDataStore(db, this.eventHandler);
     this._verificationStore = new VerificationStore(db, this.eventHandler);
@@ -175,6 +180,7 @@ class Engine extends TypedEmitter<EngineEvents> {
       this._linkStore.pruneSizeLimit +
       this._reactionStore.pruneSizeLimit +
       this._tagStore.pruneSizeLimit +
+      this._objectStore.pruneSizeLimit +
       this._castStore.pruneSizeLimit +
       this._userDataStore.pruneSizeLimit +
       this._verificationStore.pruneSizeLimit +
@@ -343,6 +349,7 @@ class Engine extends TypedEmitter<EngineEvents> {
     const linkMessages: IndexedMessage[] = [];
     const reactionMessages: IndexedMessage[] = [];
     const tagMessages: IndexedMessage[] = [];
+    const objectMessages: IndexedMessage[] = [];
     const castMessages: IndexedMessage[] = [];
     const userDataMessages: IndexedMessage[] = [];
     const verificationMessages: IndexedMessage[] = [];
@@ -374,6 +381,10 @@ class Engine extends TypedEmitter<EngineEvents> {
           tagMessages.push({ i, message });
           break;
         }
+        case UserPostfix.ObjectMessage: {
+          objectMessages.push({ i, message });
+          break;
+        }
         case UserPostfix.CastMessage: {
           castMessages.push({ i, message });
           break;
@@ -400,6 +411,7 @@ class Engine extends TypedEmitter<EngineEvents> {
       this._linkStore,
       this._reactionStore,
       this._tagStore,
+      this._objectStore,
       this._castStore,
       this._userDataStore,
       this._verificationStore,
@@ -409,6 +421,7 @@ class Engine extends TypedEmitter<EngineEvents> {
       linkMessages,
       reactionMessages,
       tagMessages,
+      objectMessages,
       castMessages,
       userDataMessages,
       verificationMessages,
@@ -493,6 +506,9 @@ class Engine extends TypedEmitter<EngineEvents> {
         case UserPostfix.TagMessage: {
           return this._tagStore.revoke(message.value);
         }
+        case UserPostfix.ObjectMessage: {
+          return this._objectStore.revoke(message.value);
+        }
         case UserPostfix.CastMessage: {
           return this._castStore.revoke(message.value);
         }
@@ -559,6 +575,9 @@ class Engine extends TypedEmitter<EngineEvents> {
     const tagResult = await this._tagStore.pruneMessages(fid);
     totalPruned += logPruneResult(tagResult, "tag");
 
+    const objectResult = await this._objectStore.pruneMessages(fid);
+    totalPruned += logPruneResult(objectResult, "object");
+
     const verificationResult = await this._verificationStore.pruneMessages(fid);
     totalPruned += logPruneResult(verificationResult, "verification");
 
@@ -592,6 +611,9 @@ class Engine extends TypedEmitter<EngineEvents> {
         }
         case UserPostfix.TagMessage: {
           return this._tagStore.revoke(message);
+        }
+        case UserPostfix.ObjectMessage: {
+          return this._objectStore.revoke(message);
         }
         case UserPostfix.CastMessage: {
           return this._castStore.revoke(message);
@@ -812,6 +834,37 @@ class Engine extends TypedEmitter<EngineEvents> {
       (e) => e as HubError,
     );
   }
+
+  /* -------------------------------------------------------------------------- */
+  /*                              Object Store Methods                             */
+  /* -------------------------------------------------------------------------- */
+
+  async getObject(fid: number, hash: Uint8Array): HubAsyncResult<ObjectAddMessage> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
+    return ResultAsync.fromPromise(this._objectStore.getObjectAdd(fid, hash), (e) => e as HubError);
+  }
+
+  async getObjectsByFid(
+    fid: number,
+    type?: string,
+    pageOptions?: PageOptions,
+  ): HubAsyncResult<MessagesPage<ObjectAddMessage>> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
+    return ResultAsync.fromPromise(
+      this._objectStore.getObjectAddsByFid(fid, type, pageOptions),
+      (e) => e as HubError,
+    );
+  }
+
+  // VLAD-TODO: add getAllObjectMessagesByFid ?
 
   /* -------------------------------------------------------------------------- */
   /*                          Verification Store Methods                        */

--- a/apps/hubble/src/storage/stores/objectStore.ts
+++ b/apps/hubble/src/storage/stores/objectStore.ts
@@ -1,0 +1,102 @@
+import {
+  CastId,
+  Message,
+  ObjectAddMessage,
+  ObjectRemoveMessage,
+  StoreType,
+  getDefaultStoreLimit,
+} from "@farcaster/hub-nodejs";
+import {
+  rsCreateObjectStore,
+  rsGetObjectAdd,
+  rsGetObjectAddsByFid,
+  rsGetObjectRemove,
+  rsGetObjectRemovesByFid,
+  rustErrorToHubError,
+} from "../../rustfunctions.js";
+import StoreEventHandler from "./storeEventHandler.js";
+import { MessagesPage, PageOptions, StorePruneOptions } from "./types.js";
+import { UserPostfix } from "../db/types.js";
+import { ResultAsync } from "neverthrow";
+import RocksDB from "storage/db/rocksdb.js";
+import { RustStoreBase } from "./rustStoreBase.js";
+import { messageDecode } from "../../storage/db/message.js";
+
+class ObjectStore extends RustStoreBase<ObjectAddMessage, ObjectRemoveMessage> {
+  constructor(db: RocksDB, eventHandler: StoreEventHandler, options: StorePruneOptions = {}) {
+    const pruneSizeLimit = options.pruneSizeLimit ?? getDefaultStoreLimit(StoreType.REACTIONS);
+    const objectsStore = rsCreateObjectStore(db.rustDb, eventHandler.getRustStoreEventHandler(), pruneSizeLimit);
+
+    super(db, objectsStore, UserPostfix.ObjectMessage, eventHandler, pruneSizeLimit);
+  }
+
+  /** Looks up ObjectAdd message by object tsHash */
+  async getObjectAdd(fid: number, hash: Uint8Array): Promise<ObjectAddMessage> {
+    const hashBytes = Buffer.from(hash);
+    const result = await ResultAsync.fromPromise(
+      rsGetObjectAdd(this._rustStore, fid, hashBytes),
+      rustErrorToHubError,
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return messageDecode(new Uint8Array(result.value)) as ObjectAddMessage;
+  }
+
+  /** Looks up ObjectRemove message by target_hash tsHash */
+  async getObjectRemove(fid: number, hash: Uint8Array): Promise<ObjectRemoveMessage> {
+    const hashBytes = Buffer.from(hash);
+    const result = await ResultAsync.fromPromise(
+      rsGetObjectRemove(this._rustStore, fid, hashBytes),
+      rustErrorToHubError,
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return messageDecode(new Uint8Array(result.value)) as ObjectRemoveMessage;
+  }
+
+  async getObjectAddsByFid(
+    fid: number,
+    type?: string,
+    pageOptions?: PageOptions,
+  ): Promise<MessagesPage<ObjectAddMessage>> {
+    const messages_page = await rsGetObjectAddsByFid(
+      this._rustStore,
+      fid,
+      type ?? "",
+      pageOptions ?? {},
+    );
+
+    const messages =
+      messages_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as ObjectAddMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: messages_page.nextPageToken };
+  }
+
+  async getObjectRemovesByFid(
+    fid: number,
+    value?: string,
+    pageOptions?: PageOptions,
+  ): Promise<MessagesPage<ObjectRemoveMessage>> {
+    const message_page = await rsGetObjectRemovesByFid(this._rustStore, fid, value ?? "", pageOptions ?? {});
+
+    const messages =
+      message_page.messageBytes?.map((message_bytes) => {
+        return messageDecode(new Uint8Array(message_bytes)) as ObjectRemoveMessage;
+      }) ?? [];
+
+    return { messages, nextPageToken: message_page.nextPageToken };
+  }
+
+  async getAllTagMessagesByFid(
+    fid: number,
+    pageOptions: PageOptions = {},
+  ): Promise<MessagesPage<ObjectAddMessage | ObjectRemoveMessage>> {
+    return await this.getAllMessagesByFid(fid, pageOptions);
+  }
+}
+
+export default ObjectStore;

--- a/packages/core/src/builders.ts
+++ b/packages/core/src/builders.ts
@@ -27,6 +27,8 @@ type MessageBodyOptions = Pick<
   | "usernameProofBody"
   | "frameActionBody"
   | "tagBody"
+  | "objectAddBody"
+  | "objectRemoveBody"
 >;
 
 /** Generic Methods */
@@ -267,6 +269,49 @@ export const makeTagRemoveData = (
   dataOptions: MessageDataOptions,
 ): HubAsyncResult<protobufs.TagRemoveData> => {
   return makeMessageData({ tagBody: body }, protobufs.MessageType.TAG_REMOVE, dataOptions);
+};
+
+
+/* -------------------------------------------------------------------------- */
+/*                                 OBJECT METHODS                             */
+/* -------------------------------------------------------------------------- */
+
+export const makeObjectAdd = async (
+  body: protobufs.ObjectAddBody,
+  dataOptions: MessageDataOptions,
+  signer: Signer,
+): HubAsyncResult<protobufs.TagAddMessage> => {
+  const data = await makeObjectAddData(body, dataOptions);
+  if (data.isErr()) {
+    return err(data.error);
+  }
+  return makeMessage(data.value, signer);
+};
+
+export const makeObjectRemove = async (
+  body: protobufs.ObjectRemoveBody,
+  dataOptions: MessageDataOptions,
+  signer: Signer,
+): HubAsyncResult<protobufs.TagRemoveMessage> => {
+  const data = await makeObjectRemoveData(body, dataOptions);
+  if (data.isErr()) {
+    return err(data.error);
+  }
+  return makeMessage(data.value, signer);
+};
+
+export const makeObjectAddData = (
+  body: protobufs.ObjectAddBody,
+  dataOptions: MessageDataOptions,
+): HubAsyncResult<protobufs.TagAddData> => {
+  return makeMessageData({ objectAddBody: body }, protobufs.MessageType.OBJECT_ADD, dataOptions);
+};
+
+export const makeObjectRemoveData = (
+  body: protobufs.ObjectRemoveBody,
+  dataOptions: MessageDataOptions,
+): HubAsyncResult<protobufs.ObjectRemoveData> => {
+  return makeMessageData({ castRemoveBody: body }, protobufs.MessageType.OBJECT_REMOVE, dataOptions);
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/core/src/protobufs/generated/request_response.ts
+++ b/packages/core/src/protobufs/generated/request_response.ts
@@ -16,6 +16,7 @@ import {
 import { OnChainEvent, OnChainEventType, onChainEventTypeFromJSON, onChainEventTypeToJSON } from "./onchain_event";
 import { UserNameProof } from "./username_proof";
 
+/** VLAD-TODO: feels like something that our new object types should be hooked into? */
 export enum StoreType {
   NONE = 0,
   CASTS = 1,
@@ -229,6 +230,14 @@ export interface TagsByTargetRequest {
   targetCastId?: CastId | undefined;
   targetUrl?: string | undefined;
   value?: string | undefined;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+}
+
+export interface ObjectsByFidRequest {
+  fid: number;
+  type?: string | undefined;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
   reverse?: boolean | undefined;
@@ -2628,6 +2637,117 @@ export const TagsByTargetRequest = {
       : undefined;
     message.targetUrl = object.targetUrl ?? undefined;
     message.value = object.value ?? undefined;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseObjectsByFidRequest(): ObjectsByFidRequest {
+  return { fid: 0, type: undefined, pageSize: undefined, pageToken: undefined, reverse: undefined };
+}
+
+export const ObjectsByFidRequest = {
+  encode(message: ObjectsByFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.type !== undefined) {
+      writer.uint32(18).string(message.type);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(24).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(34).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ObjectsByFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseObjectsByFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ObjectsByFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      type: isSet(object.type) ? String(object.type) : undefined,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+    };
+  },
+
+  toJSON(message: ObjectsByFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.type !== undefined && (obj.type = message.type);
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(base?: I): ObjectsByFidRequest {
+    return ObjectsByFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(object: I): ObjectsByFidRequest {
+    const message = createBaseObjectsByFidRequest();
+    message.fid = object.fid ?? 0;
+    message.type = object.type ?? undefined;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;

--- a/packages/core/src/protobufs/types.ts
+++ b/packages/core/src/protobufs/types.ts
@@ -96,6 +96,26 @@ export type TagRemoveMessage = protobufs.Message & {
   signatureScheme: protobufs.SignatureScheme.ED25519;
 };
 
+export type ObjectAddData = protobufs.MessageData & {
+  type: protobufs.MessageType.OBJECT_ADD;
+  objectAddBody: protobufs.ObjectAddBody;
+};
+
+export type ObjectAddMessage = protobufs.Message & {
+  data: ObjectAddData;
+  signatureScheme: protobufs.SignatureScheme.ED25519;
+};
+
+export type ObjectRemoveData = protobufs.MessageData & {
+  type: protobufs.MessageType.OBJECT_REMOVE;
+  castRemoveBody: protobufs.ObjectRemoveBody;
+};
+
+export type ObjectRemoveMessage = protobufs.Message & {
+  data: ObjectRemoveData;
+  signatureScheme: protobufs.SignatureScheme.ED25519;
+};
+
 export type VerificationAddAddressData = protobufs.MessageData & {
   type: protobufs.MessageType.VERIFICATION_ADD_ETH_ADDRESS;
   verificationAddAddressBody: protobufs.VerificationAddAddressBody;

--- a/packages/hub-nodejs/src/generated/request_response.ts
+++ b/packages/hub-nodejs/src/generated/request_response.ts
@@ -16,6 +16,7 @@ import {
 import { OnChainEvent, OnChainEventType, onChainEventTypeFromJSON, onChainEventTypeToJSON } from "./onchain_event";
 import { UserNameProof } from "./username_proof";
 
+/** VLAD-TODO: feels like something that our new object types should be hooked into? */
 export enum StoreType {
   NONE = 0,
   CASTS = 1,
@@ -229,6 +230,14 @@ export interface TagsByTargetRequest {
   targetCastId?: CastId | undefined;
   targetUrl?: string | undefined;
   value?: string | undefined;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+}
+
+export interface ObjectsByFidRequest {
+  fid: number;
+  type?: string | undefined;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
   reverse?: boolean | undefined;
@@ -2628,6 +2637,117 @@ export const TagsByTargetRequest = {
       : undefined;
     message.targetUrl = object.targetUrl ?? undefined;
     message.value = object.value ?? undefined;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseObjectsByFidRequest(): ObjectsByFidRequest {
+  return { fid: 0, type: undefined, pageSize: undefined, pageToken: undefined, reverse: undefined };
+}
+
+export const ObjectsByFidRequest = {
+  encode(message: ObjectsByFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.type !== undefined) {
+      writer.uint32(18).string(message.type);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(24).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(34).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ObjectsByFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseObjectsByFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ObjectsByFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      type: isSet(object.type) ? String(object.type) : undefined,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+    };
+  },
+
+  toJSON(message: ObjectsByFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.type !== undefined && (obj.type = message.type);
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(base?: I): ObjectsByFidRequest {
+    return ObjectsByFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(object: I): ObjectsByFidRequest {
+    const message = createBaseObjectsByFidRequest();
+    message.fid = object.fid ?? 0;
+    message.type = object.type ?? undefined;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;

--- a/packages/hub-nodejs/src/generated/rpc.ts
+++ b/packages/hub-nodejs/src/generated/rpc.ts
@@ -14,7 +14,7 @@ import {
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
 import { HubEvent } from "./hub_event";
-import { CastId, Message } from "./message";
+import { CastId, Message, ObjectId } from "./message";
 import { OnChainEvent } from "./onchain_event";
 import {
   CastsByParentRequest,
@@ -31,6 +31,7 @@ import {
   LinksByFidRequest,
   LinksByTargetRequest,
   MessagesResponse,
+  ObjectsByFidRequest,
   OnChainEventRequest,
   OnChainEventResponse,
   ReactionRequest,
@@ -220,6 +221,28 @@ export const HubServiceService = {
     responseStream: false,
     requestSerialize: (value: TagsByTargetRequest) => Buffer.from(TagsByTargetRequest.encode(value).finish()),
     requestDeserialize: (value: Buffer) => TagsByTargetRequest.decode(value),
+    responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
+  },
+  /**
+   * Objects
+   * @http-api: tagById
+   */
+  getObject: {
+    path: "/HubService/GetObject",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: ObjectId) => Buffer.from(ObjectId.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => ObjectId.decode(value),
+    responseSerialize: (value: Message) => Buffer.from(Message.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => Message.decode(value),
+  },
+  getObjectsByFid: {
+    path: "/HubService/GetObjectsByFid",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: ObjectsByFidRequest) => Buffer.from(ObjectsByFidRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => ObjectsByFidRequest.decode(value),
     responseSerialize: (value: MessagesResponse) => Buffer.from(MessagesResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => MessagesResponse.decode(value),
   },
@@ -570,6 +593,12 @@ export interface HubServiceServer extends UntypedServiceImplementation {
   getTagsByCast: handleUnaryCall<TagsByTargetRequest, MessagesResponse>;
   getTagsByTarget: handleUnaryCall<TagsByTargetRequest, MessagesResponse>;
   /**
+   * Objects
+   * @http-api: tagById
+   */
+  getObject: handleUnaryCall<ObjectId, Message>;
+  getObjectsByFid: handleUnaryCall<ObjectsByFidRequest, MessagesResponse>;
+  /**
    * User Data
    * @http-api: none
    */
@@ -879,6 +908,37 @@ export interface HubServiceClient extends Client {
   ): ClientUnaryCall;
   getTagsByTarget(
     request: TagsByTargetRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  /**
+   * Objects
+   * @http-api: tagById
+   */
+  getObject(request: ObjectId, callback: (error: ServiceError | null, response: Message) => void): ClientUnaryCall;
+  getObject(
+    request: ObjectId,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: Message) => void,
+  ): ClientUnaryCall;
+  getObject(
+    request: ObjectId,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: Message) => void,
+  ): ClientUnaryCall;
+  getObjectsByFid(
+    request: ObjectsByFidRequest,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  getObjectsByFid(
+    request: ObjectsByFidRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: MessagesResponse) => void,
+  ): ClientUnaryCall;
+  getObjectsByFid(
+    request: ObjectsByFidRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: MessagesResponse) => void,

--- a/packages/hub-nodejs/src/scripts/object_test.ts
+++ b/packages/hub-nodejs/src/scripts/object_test.ts
@@ -1,0 +1,84 @@
+import {
+  FarcasterNetwork,
+  getInsecureHubRpcClient,
+  makeCastAdd,
+  makeTagAdd,
+  makeObjectAdd,
+  NobleEd25519Signer,
+} from "@farcaster/hub-nodejs";
+import { hexToBytes } from "@noble/hashes/utils";
+
+/**
+ * Populate the following constants with your own values
+ */
+
+// {
+//   "app": {
+//     "custody": {
+//       "address": "0x98a2d6B9e4aFFAC7682902e7d9668AC539caC6dA",
+//       "key": "0x8f9fa310221f5b56fd6efceee571c67cead6905d55262be97ad63c8aba863376"
+//     },
+//     "fid": "691016"
+//   },
+//   "alice": {
+//     "custody": {
+//       "address": "0xE6A6206FD9d0CDFF797f3aBE96F6444fdBD679E3",
+//       "key": "0xaa29d02c02da27dbf2e4d98883e1b9d8adea936889332c0b5942e992b330c5f4"
+//     },
+//     "signing": {
+//       "address": "0x11428b1025ce1731b42498b6a87f32b91ddb855a4a40ad04a8cb5b8a61076cc8",
+//       "key": "0xe3bfdf6f5d5f0a807aa873c82d6fbf331249a33d51f14441baacf5b76b7c8708"
+//     }
+//   }
+// }
+
+const SIGNER = "0xe3bfdf6f5d5f0a807aa873c82d6fbf331249a33d51f14441baacf5b76b7c8708";
+// Fid owned by the custody address
+const FID = 691017; // <REQUIRED>
+
+// Testnet Configuration
+const HUB_URL = "127.0.0.1:2283"; // URL + Port of the Hub
+const NETWORK = FarcasterNetwork.DEVNET; // Network of the Hub
+
+(async () => {
+  // Set up the signer
+  const privateKeyBytes = hexToBytes(SIGNER.slice(2));
+  const ed25519Signer = new NobleEd25519Signer(privateKeyBytes);
+  // const signerPublicKey = (await ed25519Signer.getSignerKey())._unsafeUnwrap();
+
+  const dataOptions = {
+    fid: FID,
+    network: NETWORK,
+  };
+
+  const ObjType = "VladObj";
+  // If your client does not use SSL.
+  const client = getInsecureHubRpcClient(HUB_URL);
+
+  const objectAdd = await makeObjectAdd({
+    type: ObjType,
+    displayName: "Vlad OBJ CUZ 2",
+    avatar: "https://i.pinimg.com/474x/36/f3/89/36f38906aa7073156b19e445a74d03f2.jpg",
+    description: "Vlad's awesome custom object numba 2"
+  },
+  dataOptions,
+  ed25519Signer);
+
+  console.log('ObjectAdd message', objectAdd);
+  const tag = await client.submitMessage(objectAdd._unsafeUnwrap());
+  console.log(tag._unsafeUnwrap().data?.objectAddBody);
+
+  const y = await client.getObjectsByFid({ fid: FID, type: ObjType });
+
+  if (y.isOk()) {
+    console.log(y._unsafeUnwrap().messages.map(m => m.data));
+  } else if (y.isErr()) {
+    console.log('ERROR', y.error);
+  }
+
+  // const y = await client.getTagsByFid({ fid: FID, value: 'testTag' });
+  // console.log(`Found ${y._unsafeUnwrap().messages.length} tags.`);
+  // console.log(JSON.stringify(y._unsafeUnwrap(), null, 2));
+
+  client.close();
+})();

--- a/packages/hub-web/src/generated/request_response.ts
+++ b/packages/hub-web/src/generated/request_response.ts
@@ -16,6 +16,7 @@ import {
 import { OnChainEvent, OnChainEventType, onChainEventTypeFromJSON, onChainEventTypeToJSON } from "./onchain_event";
 import { UserNameProof } from "./username_proof";
 
+/** VLAD-TODO: feels like something that our new object types should be hooked into? */
 export enum StoreType {
   NONE = 0,
   CASTS = 1,
@@ -229,6 +230,14 @@ export interface TagsByTargetRequest {
   targetCastId?: CastId | undefined;
   targetUrl?: string | undefined;
   value?: string | undefined;
+  pageSize?: number | undefined;
+  pageToken?: Uint8Array | undefined;
+  reverse?: boolean | undefined;
+}
+
+export interface ObjectsByFidRequest {
+  fid: number;
+  type?: string | undefined;
   pageSize?: number | undefined;
   pageToken?: Uint8Array | undefined;
   reverse?: boolean | undefined;
@@ -2628,6 +2637,117 @@ export const TagsByTargetRequest = {
       : undefined;
     message.targetUrl = object.targetUrl ?? undefined;
     message.value = object.value ?? undefined;
+    message.pageSize = object.pageSize ?? undefined;
+    message.pageToken = object.pageToken ?? undefined;
+    message.reverse = object.reverse ?? undefined;
+    return message;
+  },
+};
+
+function createBaseObjectsByFidRequest(): ObjectsByFidRequest {
+  return { fid: 0, type: undefined, pageSize: undefined, pageToken: undefined, reverse: undefined };
+}
+
+export const ObjectsByFidRequest = {
+  encode(message: ObjectsByFidRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.fid !== 0) {
+      writer.uint32(8).uint64(message.fid);
+    }
+    if (message.type !== undefined) {
+      writer.uint32(18).string(message.type);
+    }
+    if (message.pageSize !== undefined) {
+      writer.uint32(24).uint32(message.pageSize);
+    }
+    if (message.pageToken !== undefined) {
+      writer.uint32(34).bytes(message.pageToken);
+    }
+    if (message.reverse !== undefined) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ObjectsByFidRequest {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseObjectsByFidRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag != 8) {
+            break;
+          }
+
+          message.fid = longToNumber(reader.uint64() as Long);
+          continue;
+        case 2:
+          if (tag != 18) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        case 3:
+          if (tag != 24) {
+            break;
+          }
+
+          message.pageSize = reader.uint32();
+          continue;
+        case 4:
+          if (tag != 34) {
+            break;
+          }
+
+          message.pageToken = reader.bytes();
+          continue;
+        case 5:
+          if (tag != 40) {
+            break;
+          }
+
+          message.reverse = reader.bool();
+          continue;
+      }
+      if ((tag & 7) == 4 || tag == 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ObjectsByFidRequest {
+    return {
+      fid: isSet(object.fid) ? Number(object.fid) : 0,
+      type: isSet(object.type) ? String(object.type) : undefined,
+      pageSize: isSet(object.pageSize) ? Number(object.pageSize) : undefined,
+      pageToken: isSet(object.pageToken) ? bytesFromBase64(object.pageToken) : undefined,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : undefined,
+    };
+  },
+
+  toJSON(message: ObjectsByFidRequest): unknown {
+    const obj: any = {};
+    message.fid !== undefined && (obj.fid = Math.round(message.fid));
+    message.type !== undefined && (obj.type = message.type);
+    message.pageSize !== undefined && (obj.pageSize = Math.round(message.pageSize));
+    message.pageToken !== undefined &&
+      (obj.pageToken = message.pageToken !== undefined ? base64FromBytes(message.pageToken) : undefined);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(base?: I): ObjectsByFidRequest {
+    return ObjectsByFidRequest.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ObjectsByFidRequest>, I>>(object: I): ObjectsByFidRequest {
+    const message = createBaseObjectsByFidRequest();
+    message.fid = object.fid ?? 0;
+    message.type = object.type ?? undefined;
     message.pageSize = object.pageSize ?? undefined;
     message.pageToken = object.pageToken ?? undefined;
     message.reverse = object.reverse ?? undefined;

--- a/protobufs/schemas/message.proto
+++ b/protobufs/schemas/message.proto
@@ -41,7 +41,9 @@ message MessageData {
     LinkCompactStateBody link_compact_state_body = 17;
 
     TagBody tag_body = 18;
-    ObjectBody object_body = 19;
+
+    ObjectAddBody object_add_body = 19;
+    ObjectRemoveBody object_remove_body = 20;
 
   } // Properties specific to the MessageType
 }
@@ -79,6 +81,8 @@ enum MessageType {
   MESSAGE_TYPE_LINK_COMPACT_STATE = 14; // Link Compaction State Message
   MESSAGE_TYPE_TAG_ADD = 15; // Add a Tag to a Cast
   MESSAGE_TYPE_TAG_REMOVE = 16; // Remove a Tag from a Cast
+  MESSAGE_TYPE_OBJECT_ADD = 17; // Add a Tag to a Cast
+  MESSAGE_TYPE_OBJECT_REMOVE = 18; // Remove a Tag from a Cast
 }
 
 /** Farcaster network the message is intended for */
@@ -148,7 +152,7 @@ message ReactionBody {
 /* Generic reference to an H1/H2 object */
 message ObjectKey {
   FarcasterNetwork network = 1;
-  string key = 2; // TODO: figure out the type
+  string key = 2; // Key to look up the object with within RocksDB
 }
 
 message ObjectRef {
@@ -162,15 +166,26 @@ message ObjectRef {
 message TagBody {
   string name = 1; // Tag value
   optional string content = 2;
-  ObjectRef target = 3;
+  ObjectRef target = 3;  
+}
+
+/** Identifier used to look up an H2 Object (equivalent to CastId atm) */
+message ObjectId {
+  uint64 fid = 1; // Fid of the user who created the object
+  bytes hash = 2; // Hash of the object
 }
 
 /* Generic object at H2 */
-message ObjectBody {
-  string type = 1;
+message ObjectAddBody {
+  string type = 1; // Type of object (completely user-defined, thus a string)
   optional string displayName = 2;
-  optional string avatar = 3;
+  optional string avatar = 3; // base64 encoded image or a URL?
 	optional string description = 4;
+}
+
+/** Removes an existing Cast */
+message ObjectRemoveBody {
+  bytes target_hash = 1; // Hash of the object to remove
 }
 
 /** Type of Reaction */

--- a/protobufs/schemas/request_response.proto
+++ b/protobufs/schemas/request_response.proto
@@ -174,6 +174,14 @@ message TagsByTargetRequest {
   optional bool reverse = 5;
 }
 
+message ObjectsByFidRequest {
+  uint64 fid = 1;
+  optional string type = 2;
+  optional uint32 page_size = 3;
+  optional bytes page_token = 4;
+  optional bool reverse = 5;
+}
+
 message UserDataRequest {
   uint64 fid = 1;
   UserDataType user_data_type = 2;
@@ -205,6 +213,7 @@ message StorageLimitsResponse {
   uint32 units = 2;
 }
 
+// VLAD-TODO: feels like something that our new object types should be hooked into?
 enum StoreType {
   STORE_TYPE_NONE = 0;
   STORE_TYPE_CASTS = 1;

--- a/protobufs/schemas/rpc.proto
+++ b/protobufs/schemas/rpc.proto
@@ -48,6 +48,11 @@ service HubService {
   rpc GetTagsByCast(TagsByTargetRequest) returns (MessagesResponse); // To be deprecated
   rpc GetTagsByTarget(TagsByTargetRequest) returns (MessagesResponse);
 
+ // Objects
+  // @http-api: objectById
+  rpc GetObject(ObjectId) returns (Message);
+  rpc GetObjectsByFid(ObjectsByFidRequest) returns (MessagesResponse);
+
   // User Data
   // @http-api: none
   rpc GetUserData(UserDataRequest) returns (Message);


### PR DESCRIPTION
Dang, @vleipnik wasn't kidding when he said there's a lot of copy-pasta code required to create a brand-new hubble data type. Definitely feels like they could have streamlined it a bit more if they cared to make it easier.

I've only tested creating new `ObjectAddBody` msgs and then reading them back via `GET /v1/objectsByFid` endpoint. There's a new `test-obj-script` under `hub-nodejs` package for that.